### PR TITLE
fix: ui overrides when model not registered yet

### DIFF
--- a/template/ui/{{model_name}}/__init__.py.copier
+++ b/template/ui/{{model_name}}/__init__.py.copier
@@ -71,6 +71,7 @@ def ui_overrides(app):
 
     if (
         current_oarepo_ui is not None
+        and ui_resource_config.model
         and ui_resource_config.model.record_json_schema
         and ui_resource_config.search_component
     ):


### PR DESCRIPTION
Together with https://github.com/oarepo/oarepo-ui/pull/371/commits/889a53a99ff9eb0b13c95cabf7121ad01686e3f4: fixes crash when running ./run.sh install.

It crashed on entrypoint load when regular invenio cmd is invoked *before* invenio-cli runs full .venv setup (links invenio.cfg to .venv)
```
Failed to initialize entry point: EntryPoint(name='ui_datasets', value='ui.datasets:finalize_app', group='invenio_base.finalize_app')
    return current_runtime.models[self.model_name]
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'datasets'
```
It allows to run invenio commands like the one below, before invenio-cli is run to fully initialize .venv:
```
uv run invenio shell --no-term-title -c 'print(app.instance_path, end='\'''\'')'
```