### PR TITLE
Replace EmptyRecordAccessComponent with RestrictedFromCommunityComponent (rdm_minimal)

### DIFF
--- a/template/ui/{{model_name}}/{% if base_model in ('empty', 'rdm_minimal') %}__init__.py{% endif %}.copier
+++ b/template/ui/{{model_name}}/{% if base_model in ('empty', 'rdm_minimal') %}__init__.py{% endif %}.copier
@@ -5,14 +5,18 @@ from oarepo_ui.resources.components import (
     PermissionsComponent,
 {% if base_model == 'rdm_minimal' %}
     CustomFieldsComponent,
-    EmptyRecordAccessComponent,
     FilesLockedComponent,
     FilesQuotaAndTransferComponent,
     RecordRestrictionComponent,
 {% endif %}
 )
 {% if base_model == 'rdm_minimal' or base_model == 'empty' %}
-from oarepo_rdm.ui.components import FilesEnabledComponent
+from oarepo_rdm.ui.components import (
+    FilesEnabledComponent,
+{% if base_model == 'rdm_minimal' %}
+    RestrictedFromCommunityComponent,
+{% endif %}
+)
 {% endif %}
 from oarepo_ui.resources.records.config import RecordsUIResourceConfig
 from oarepo_ui.resources.records.resource import RecordsUIResource
@@ -44,7 +48,7 @@ class {{resource_config}}(RecordsUIResourceConfig):
         FilesEnabledComponent,
         CustomFieldsComponent,
         RecordRestrictionComponent,
-        EmptyRecordAccessComponent,
+        RestrictedFromCommunityComponent,
         FilesLockedComponent,
         FilesQuotaAndTransferComponent,
     ]


### PR DESCRIPTION
## What

For the `rdm_minimal` base model UI resource config:

- **Removed `EmptyRecordAccessComponent`**
- **Added `RestrictedFromCommunityComponent`** (from `oarepo_rdm.ui.components`)

Both changes are scoped to `rdm_minimal` only; the `empty` base model is unchanged.

## Why remove `EmptyRecordAccessComponent`

`EmptyRecordAccessComponent` seeds the backend **empty (initial) record** with `access.record = "public"` and `access.files = "public"`. Invenio does **not** do this — it leaves access off the initial server-rendered record and instead fills the access defaults later, in the **JS deposit form serializer**. Keeping our own component made the initial record diverge from Invenio's shape. Removing it restores consistency with Invenio.

## Why add `RestrictedFromCommunityComponent`

When a record is created into a **preselected restricted community**, the record must be restricted for submission to be valid. This component runs on `before_ui_create` (after the empty-record defaults) and, when the preselected community's `access.visibility == "restricted"`, sets the new record's `access.record` and `access.files` to `"restricted"`. Setting both is required — otherwise the API `create` fails access validation with a missing `files` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)